### PR TITLE
Fix for crash when adding Tags

### DIFF
--- a/back/taiga_contrib_slack/tasks.py
+++ b/back/taiga_contrib_slack/tasks.py
@@ -154,7 +154,8 @@ def _field_to_attachment(template_field, field_name, values):
         attachment['fields'] = [
             {
                 "title": field_name,
-                "value": "*From* {} *to* {}".format(", ".join(values[0]), ", ".join(values[1])),
+                "value": "*From* {} *to* {}".format(", ".join(values[0]) if values[0] is not None else "None",
+                                                    ", ".join(values[1]) if values[1] is not None else "None"),
                 "short": True,
             },
         ]

--- a/back/taiga_contrib_slack/templates/taiga_contrib_slack/field-diff.jinja
+++ b/back/taiga_contrib_slack/templates/taiga_contrib_slack/field-diff.jinja
@@ -19,7 +19,7 @@
         {% endfor %}
     {% endif %}
 {% elif field_name in ["tags", "watchers"] %}
-    *{{ field_name }}:* from *{{ ', '.join(values.0) }} * to *{{ ', '.join(values.1) }} *
+    *{{ field_name }}:* from *{{ ', '.join(values.0) if values.0 is not none else "None" }} * to *{{ ', '.join(values.1) if values.1 is not none else "None" }} *
 {% elif field_name in ["description", "content", "blocked_note"] %}
     *{{ field_name.replace("_", " ") }}*
     {% if values.0 %}


### PR DESCRIPTION
```python
", ".join(values[0])
```

crashes when `values[0]` evaluates as `None`. So I've added a check to prevent this from happening, which stopped us from being able to add tags to our Tasks.

Instead of a list of Tags `None` will be printed when adding the first Tag or removing the last Tag.