### PR TITLE
Show better the links and the special characters on comments

### DIFF
--- a/back/taiga_contrib_slack/templates/taiga_contrib_slack/change.jinja
+++ b/back/taiga_contrib_slack/templates/taiga_contrib_slack/change.jinja
@@ -14,4 +14,4 @@
     {% set final_url = resolve_front_url("taskboard", obj.project.slug, obj.slug) %}
     {{ _("Changed Sprint: ") }} *<{{final_url}}|{{obj.name|safe}}>*
 {% endif %}
-{% if change.comment %}*Comment by {{ change.user.name }}:* {{ change.comment}}{% endif %}
+{% if comment %}*Comment by {{ change.user.name }}:* {{ comment|safe }}{% endif %}


### PR DESCRIPTION
Try to fix (not fully fixed, because the slack markdown implementation ins't compatible with the reference implementation of markdown) the issue #21 