### PR TITLE
Make sure HTTP POST requests have correct Content-Type

### DIFF
--- a/back/taiga_contrib_slack/tasks.py
+++ b/back/taiga_contrib_slack/tasks.py
@@ -39,14 +39,12 @@ def _get_type(obj):
 
 
 def _send_request(url, data):
-    serialized_data = UnicodeJSONRenderer().render(data)
-
     if settings.CELERY_ENABLED:
-        requests.post(url, data=serialized_data)
+        requests.post(url, json=data)
         return
 
     try:
-        requests.post(url, data=serialized_data)
+        requests.post(url, json=data)
     except Exception:
         logger.error("Error sending request to slack")
 


### PR DESCRIPTION
Currently, requests to Slack were missing a correct Content-Type header, and were sent with www-form-urlencoded. This was breaking Slack-compatible applications such as Mattermost.