### PR TITLE
Properly handle errors in link transform

### DIFF
--- a/back/taiga_contrib_slack/tasks.py
+++ b/back/taiga_contrib_slack/tasks.py
@@ -216,9 +216,9 @@ def _field_to_attachment(template_field, field_name, values):
     return attachment
 
 
-def _link_transform(match):
-    url_split = match.group(8).split()
+def _link_transform(match):    
     try:
+        url_split = match.group(8).split()
         return "{} ({})".format(match.group(1), url_split[0])
     except IndexError:
         return "{}".format(match.group(1))

--- a/back/taiga_contrib_slack/tasks.py
+++ b/back/taiga_contrib_slack/tasks.py
@@ -217,11 +217,13 @@ def _field_to_attachment(template_field, field_name, values):
 
 
 def _link_transform(match):    
-    try:
+    if len(match.groups()) > 8:
         url_split = match.group(8).split()
-        return "{} ({})".format(match.group(1), url_split[0])
-    except IndexError:
-        return "{}".format(match.group(1))
+        try:        
+            return "{} ({})".format(match.group(1), url_split[0])
+        except IndexError:
+            return "{}".format(match.group(1))
+    return match.group(0)
 
 
 def _check_notify_permission(notify_config, obj_type, action):


### PR DESCRIPTION
If comments contain invalid markdown links, a `IndexError` is raised since the number of match groups is not sufficient. So this should be checked and handled accordingly. In this PR the invalid markdown link is ignored.